### PR TITLE
Add command for multi-platform image build

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Downloading prebuilt images is reccomended if you are not planning to considerab
 3. Upload docker image to robot. Connect robot to your PC via USB so you can transfer image quicker. Note that currently space on the robot is limited, so you need to have 7-8 GB of free space in `/data` directory - `docker save <docker-image-name>:<tag> | ssh -C root@192.168.197.55 docker load`
 4. SSH into robot and run docker image - `docker run -it --restart=unless-stopped -v /dev/:/dev/ -v /sys/:/sys/ --privileged  --net=host <docker-image-name>:<tag>`
 5. Search for docker container name with `docker ps`
-6. Attach to the shell - `docker attach <container_name>`, or if you want to create separate session `docker exec -it <container_name> zsh
+6. Attach to the shell - `docker attach <container_name>`, or if you want to create separate session `docker exec -it <container_name> zsh`
 7. To launch robot hardware - `ros2 launch rae_bringup robot.launch.py`. This launches:
    - Motor drivers and differential controller
    - Camera driver, currently set up to provide Depth and streams from left & right camera. Note here that you have to calibrate cameras (see steps below). Currently a default calibration file is loaded. It's located in `rae_camera/config/cal.json`. To use one on the device or from other path, change `i_external_calibration_path` parameter in  `rae_camera/config/camera.yaml`
@@ -201,7 +201,7 @@ LCD node is listening to messages on /lcd topic and showing it on the screen in 
 
 `img_msg = self.bridge.cv2_to_imgmsg(img_cv, encoding="bgr8")`
 
-### Microcphone and speakers
+### Microphone and speakers
 
 Microphone node expects audio messages and example of how to use that data (along with some other peripherals) can be found in rae_bringup/scripts/audio_spectrum.py . For fair amount of use caes, you will need to decode incoming data as shown in example below.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You can download prebuilt images form [dockerhub](https://hub.docker.com/r/luxon
 Downloading prebuilt images is reccomended if you are not planning to considerably change source code. 
 
 1. Clone repository `git clone git@github.com:luxonis/rae-ros.git`
-2. Build docker image `cd rae && docker buildx build --platform arm64 --build-arg USE_RVIZ=0 --build-arg SIM=0 --build-arg ROS_DISTRO=humble --build-arg CORE_NUM=10 -f Dockerfile --squash -t <docker-image-name>:<tag> --load .
+2. Build docker image `cd rae && docker run --privileged --rm tonistiigi/binfmt --install all && docker buildx build --platform arm64 --build-arg USE_RVIZ=0 --build-arg SIM=0 --build-arg ROS_DISTRO=humble --build-arg CORE_NUM=10 -f Dockerfile --squash -t <docker-image-name>:<tag> --load .
 `
 3. Upload docker image to robot. Connect robot to your PC via USB so you can transfer image quicker. Note that currently space on the robot is limited, so you need to have 7-8 GB of free space in `/data` directory - `docker save <docker-image-name>:<tag> | ssh -C root@192.168.197.55 docker load`
 4. SSH into robot and run docker image - `docker run -it --restart=unless-stopped -v /dev/:/dev/ -v /sys/:/sys/ --privileged  --net=host <docker-image-name>:<tag>`

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ You can download prebuilt images form [dockerhub](https://hub.docker.com/r/luxon
 Downloading prebuilt images is reccomended if you are not planning to considerably change source code. 
 
 1. Clone repository `git clone git@github.com:luxonis/rae-ros.git`
-2. Build docker image `cd rae && docker run --privileged --rm tonistiigi/binfmt --install all && docker buildx build --platform arm64 --build-arg USE_RVIZ=0 --build-arg SIM=0 --build-arg ROS_DISTRO=humble --build-arg CORE_NUM=10 -f Dockerfile --squash -t <docker-image-name>:<tag> --load .
+2. Build docker image `cd rae-ros && docker run --privileged --rm tonistiigi/binfmt --install all && docker buildx build --platform arm64 --build-arg USE_RVIZ=0 --build-arg SIM=0 --build-arg ROS_DISTRO=humble --build-arg CORE_NUM=10 -f Dockerfile --squash -t <docker-image-name>:<tag> --load .
 `
 3. Upload docker image to robot. Connect robot to your PC via USB so you can transfer image quicker. Note that currently space on the robot is limited, so you need to have 7-8 GB of free space in `/data` directory - `docker save <docker-image-name>:<tag> | ssh -C root@192.168.197.55 docker load`
 4. SSH into robot and run docker image - `docker run -it --restart=unless-stopped -v /dev/:/dev/ -v /sys/:/sys/ --privileged  --net=host <docker-image-name>:<tag>`


### PR DESCRIPTION
If the user never made multi-platform docker image build, a step 2 of the readme fails at the first RUN directives of the dockerfile with a not obvious error shown under a toggle below. This patch adds multi-platform build support as recommended in https://github.com/docker/buildx/issues/1986, https://docs.docker.com/build/building/multi-platform/#qemu.

Also minor typo fixes.

<details>
<summary>docker buildx build --platform arm64 --build-arg USE_RVIZ=0 --build-arg SIM=0 --build-arg ROS_DISTRO=humble --build-arg CORE_NUM=10 -f Dockerfile --squash -t khassanov/rae-ros-robot:humble --load .</summary>

```sh
docker buildx build --platform arm64 --build-arg USE_RVIZ=0 --build-arg SIM=0 --build-arg ROS_DISTRO=humble --build-arg CORE_NUM=10 -f Dockerfile --squash -t khassanov/rae-ros-robot:humble --load .
WARNING: experimental flag squash is removed with BuildKit. You should squash inside build using a multi-stage Dockerfile for efficiency.
[+] Building 2.3s (6/20)                                                                                                                                                             docker:default
 => [internal] load build definition from Dockerfile                                                                                                                                           0.1s
 => => transferring dockerfile: 2.12kB                                                                                                                                                         0.0s
 => [internal] load .dockerignore                                                                                                                                                              0.1s
 => => transferring context: 66B                                                                                                                                                               0.0s
 => [internal] load metadata for ghcr.io/luxonis/rae-base:2023.12.19                                                                                                                           1.5s
 => CACHED [ 1/16] FROM ghcr.io/luxonis/rae-base:2023.12.19@sha256:df6ceda4432b3839da9d737178f0b34628f28012dfbb2d614640885888d8b243                                                            0.0s
 => [internal] load build context                                                                                                                                                              0.1s
 => => transferring context: 10.64kB                                                                                                                                                           0.0s
 => ERROR [ 2/16] RUN apt-get update && apt-get -y install --no-install-recommends     software-properties-common     libusb-1.0-0-dev     python3-colcon-common-extensions     python3-rosde  0.5s
------                                                                                                                                                                                              
 > [ 2/16] RUN apt-get update && apt-get -y install --no-install-recommends     software-properties-common     libusb-1.0-0-dev     python3-colcon-common-extensions     python3-rosdep     build-essential     gpiod     libasound2-dev     ros-humble-cv-bridge     ros-humble-image-transport     ros-humble-image-transport-plugins     ros-humble-rmw-cyclonedds-cpp     gstreamer1.0-plugins-bad     alsa-utils     mpg123     libmpg123-dev     ros-humble-rtabmap-slam     unzip     ffmpeg     ros-humble-image-proc     git     htop     libsndfile1-dev     libsndfile1:
0.395 exec /bin/sh: exec format error
------
Dockerfile:7
--------------------
   6 |     
   7 | >>> RUN apt-get update && apt-get -y install --no-install-recommends \
   8 | >>>     software-properties-common \
   9 | >>>     libusb-1.0-0-dev \
  10 | >>>     python3-colcon-common-extensions \
  11 | >>>     python3-rosdep \
  12 | >>>     build-essential \
  13 | >>>     gpiod \
  14 | >>>     libasound2-dev \
  15 | >>>     ros-humble-cv-bridge \ 
  16 | >>>     ros-humble-image-transport \
  17 | >>>     ros-humble-image-transport-plugins \
  18 | >>>     ros-humble-rmw-cyclonedds-cpp \
  19 | >>>     gstreamer1.0-plugins-bad \
  20 | >>>     alsa-utils \
  21 | >>>     mpg123 \
  22 | >>>     libmpg123-dev \
  23 | >>>     ros-humble-rtabmap-slam \ 
  24 | >>>     unzip \
  25 | >>>     ffmpeg \
  26 | >>>     ros-humble-image-proc \
  27 | >>>     git \
  28 | >>>     htop \
  29 | >>>     libsndfile1-dev \
  30 | >>>     libsndfile1
  31 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c apt-get update && apt-get -y install --no-install-recommends     software-properties-common     libusb-1.0-0-dev     python3-colcon-common-extensions     python3-rosdep     build-essential     gpiod     libasound2-dev     ros-humble-cv-bridge     ros-humble-image-transport     ros-humble-image-transport-plugins     ros-humble-rmw-cyclonedds-cpp     gstreamer1.0-plugins-bad     alsa-utils     mpg123     libmpg123-dev     ros-humble-rtabmap-slam     unzip     ffmpeg     ros-humble-image-proc     git     htop     libsndfile1-dev     libsndfile1" did not complete successfully: exit code: 1
```
</details>