### PR TITLE
Mic and speaker update

### DIFF
--- a/rae_hw/include/rae_hw/peripherals/mic.hpp
+++ b/rae_hw/include/rae_hw/peripherals/mic.hpp
@@ -39,6 +39,7 @@ class MicNode : public rclcpp_lifecycle::LifecycleNode {
     snd_pcm_t* handle_;
     bool recording_;
     std::string wav_filename_;
+    void applyLowPassFilter(std::vector<int32_t>& buffer);
     rclcpp::Service<rae_msgs::srv::RecordAudio>::SharedPtr start_service_;
     rclcpp::Service<rae_msgs::srv::StopRecording>::SharedPtr stop_service_;
     rclcpp::TimerBase::SharedPtr stop_timer_;

--- a/rae_hw/include/rae_hw/peripherals/mic.hpp
+++ b/rae_hw/include/rae_hw/peripherals/mic.hpp
@@ -3,6 +3,8 @@
 #include <sndfile.h>
 
 #include <rae_msgs/srv/record_audio.hpp>
+#include <rae_msgs/srv/stop_recording.hpp>
+
 #include <rclcpp_action/rclcpp_action.hpp>
 #include <vector>
 
@@ -11,7 +13,6 @@
 #include "rae_msgs/msg/rae_audio.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"
-#include "std_srvs/srv/trigger.hpp"
 
 namespace rae_hw {
 using CallbackReturn = rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
@@ -39,10 +40,13 @@ class MicNode : public rclcpp_lifecycle::LifecycleNode {
     bool recording_;
     std::string wav_filename_;
     rclcpp::Service<rae_msgs::srv::RecordAudio>::SharedPtr start_service_;
+    rclcpp::Service<rae_msgs::srv::StopRecording>::SharedPtr stop_service_;
     rclcpp::TimerBase::SharedPtr stop_timer_;
     void startRecording(const std::shared_ptr<rae_msgs::srv::RecordAudio::Request> request,
                         const std::shared_ptr<rae_msgs::srv::RecordAudio::Response> response);
-    void stopRecording();
+    void timeoutRecording();
+    void stopRecording(const std::shared_ptr<rae_msgs::srv::StopRecording::Request> stop_request,
+                            const std::shared_ptr<rae_msgs::srv::StopRecording::Response> stop_response);
 };
 
 }  // namespace rae_hw

--- a/rae_hw/include/rae_hw/peripherals/mic.hpp
+++ b/rae_hw/include/rae_hw/peripherals/mic.hpp
@@ -4,7 +4,6 @@
 
 #include <rae_msgs/srv/record_audio.hpp>
 #include <rae_msgs/srv/stop_recording.hpp>
-
 #include <rclcpp_action/rclcpp_action.hpp>
 #include <vector>
 
@@ -47,7 +46,7 @@ class MicNode : public rclcpp_lifecycle::LifecycleNode {
                         const std::shared_ptr<rae_msgs::srv::RecordAudio::Response> response);
     void timeoutRecording();
     void stopRecording(const std::shared_ptr<rae_msgs::srv::StopRecording::Request> stop_request,
-                            const std::shared_ptr<rae_msgs::srv::StopRecording::Response> stop_response);
+                       const std::shared_ptr<rae_msgs::srv::StopRecording::Response> stop_response);
 };
 
 }  // namespace rae_hw

--- a/rae_hw/include/rae_hw/peripherals/speakers.hpp
+++ b/rae_hw/include/rae_hw/peripherals/speakers.hpp
@@ -5,7 +5,9 @@
 #include <mpg123.h>
 #include <sndfile.h>
 #include <rae_msgs/srv/play_audio.hpp>
-
+#include <iostream>
+#include <cstring>
+#include <limits>
 #include "audio_msgs/msg/audio.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"

--- a/rae_hw/include/rae_hw/peripherals/speakers.hpp
+++ b/rae_hw/include/rae_hw/peripherals/speakers.hpp
@@ -3,7 +3,7 @@
 
 #include <alsa/asoundlib.h>
 #include <mpg123.h>
-
+#include <sndfile.h>
 #include <rae_msgs/srv/play_audio.hpp>
 
 #include "audio_msgs/msg/audio.hpp"
@@ -26,6 +26,7 @@ class SpeakersNode : public rclcpp_lifecycle::LifecycleNode {
 
    private:
     void play_mp3(const char*);
+    void play_wav(const char*);
     rclcpp::Service<rae_msgs::srv::PlayAudio>::SharedPtr play_audio_service_;
 
     void play_audio_service_callback(const std::shared_ptr<rae_msgs::srv::PlayAudio::Request> request,

--- a/rae_hw/include/rae_hw/peripherals/speakers.hpp
+++ b/rae_hw/include/rae_hw/peripherals/speakers.hpp
@@ -4,10 +4,12 @@
 #include <alsa/asoundlib.h>
 #include <mpg123.h>
 #include <sndfile.h>
-#include <rae_msgs/srv/play_audio.hpp>
-#include <iostream>
+
 #include <cstring>
+#include <iostream>
 #include <limits>
+#include <rae_msgs/srv/play_audio.hpp>
+
 #include "audio_msgs/msg/audio.hpp"
 #include "rclcpp/rclcpp.hpp"
 #include "rclcpp_lifecycle/lifecycle_node.hpp"

--- a/rae_hw/include/rae_hw/rae_motors.hpp
+++ b/rae_hw/include/rae_hw/rae_motors.hpp
@@ -108,6 +108,7 @@ class RaeMotor {
     const State Clockwise{0, 1};
     const State Halfway{1, 1};
     const State Counter{1, 0};
+    float deadZoneThreshold = 4.0f;
     State prevState;
     PID currPID;
 

--- a/rae_hw/scripts/lifecycle_manager.py
+++ b/rae_hw/scripts/lifecycle_manager.py
@@ -118,7 +118,7 @@ class LifecycleManager(Node):
 
         # send startup sound
         req = PlayAudio.Request()
-        req.mp3_file = self._startup_sound_path
+        req.file_location = self._startup_sound_path
         self._audio_client.wait_for_service()
         future = self._audio_client.call_async(req)
         rclpy.spin_until_future_complete(self, future)

--- a/rae_hw/scripts/mock_speakers.py
+++ b/rae_hw/scripts/mock_speakers.py
@@ -15,7 +15,7 @@ class MockSpeakers(Node):
         self.get_logger().info('I heard: "%s"' % msg.data)
 
     def play_callback(self, request: PlayAudio.Request, response):
-        self.get_logger().info('I heard: "%s"' % request.mp3_file)
+        self.get_logger().info('I heard: "%s"' % request.file_location)
         return response
     
     def on_configure(self, state: LifecycleState) -> TransitionCallbackReturn:

--- a/rae_hw/src/peripherals/mic.cpp
+++ b/rae_hw/src/peripherals/mic.cpp
@@ -24,7 +24,8 @@ CallbackReturn MicNode::on_configure(const rclcpp_lifecycle::State& /*previous_s
     wav_filename_ = "/tmp/recording.wav";
     start_service_ = this->create_service<rae_msgs::srv::RecordAudio>("start_recording",
                                                                       std::bind(&MicNode::startRecording, this, std::placeholders::_1, std::placeholders::_2));
-    stop_service_ = this->create_service<rae_msgs::srv::StopRecording>("stop_recording", std::bind(&MicNode::stopRecording, this, std::placeholders::_1, std::placeholders::_2));
+    stop_service_ = this->create_service<rae_msgs::srv::StopRecording>("stop_recording",
+                                                                       std::bind(&MicNode::stopRecording, this, std::placeholders::_1, std::placeholders::_2));
     RCLCPP_INFO(this->get_logger(), "Mic node configured!");
     return CallbackReturn::SUCCESS;
 }
@@ -111,9 +112,9 @@ void MicNode::timer_callback() {
 void MicNode::applyLowPassFilter(std::vector<int32_t>& buffer) {
     static float prevSampleLeft = 0.0f;
     static float prevSampleRight = 0.0f;
-    const float ALPHA = 0.1f; // Smoothing factor
+    const float ALPHA = 0.1f;  // Smoothing factor
 
-    for (size_t i = 0; i < buffer.size(); i += 2) {
+    for(size_t i = 0; i < buffer.size(); i += 2) {
         // Apply low-pass filter to attenuate high frequencies for left channel
         float currentSampleLeft = static_cast<float>(buffer[i]);
         float filteredSampleLeft = prevSampleLeft + ALPHA * (currentSampleLeft - prevSampleLeft);
@@ -167,10 +168,9 @@ void MicNode::startRecording(const std::shared_ptr<rae_msgs::srv::RecordAudio::R
     // Start recording when the service is called
     recording_ = true;
     wav_filename_ = request->file_location;
-    if (stop_timer_) {
+    if(stop_timer_) {
         stop_timer_->reset();
-    }
-    else {
+    } else {
         // Create a new timer if it doesn't exist
         stop_timer_ = this->create_wall_timer(std::chrono::seconds(30), std::bind(&MicNode::timeoutRecording, this));
     }

--- a/rae_hw/src/peripherals/speakers.cpp
+++ b/rae_hw/src/peripherals/speakers.cpp
@@ -138,7 +138,7 @@ void SpeakersNode::play_wav(const char* wav_file) {
     int32_t* buffer_wav = new int32_t[BUFFER_SIZE * sfinfo.channels]; // Use int32_t for 32-bit format
     sf_count_t readCount;
 
-    const float gain = 4.0f; // Adjust this factor for desired gain
+    const float gain = 64.0f; // Adjust this factor for desired gain
 
     while ((readCount = sf_readf_int(file, buffer_wav, BUFFER_SIZE)) > 0) {
         // Apply gain to the samples

--- a/rae_hw/src/peripherals/speakers.cpp
+++ b/rae_hw/src/peripherals/speakers.cpp
@@ -49,7 +49,7 @@ void SpeakersNode::play_audio_service_callback(const std::shared_ptr<rae_msgs::s
     const std::string& file_location = request->file_location;
 
     // Check if the file ends with ".wav"
-    if (file_location.size() >= 4 && file_location.substr(file_location.size() - 4) == ".wav") {
+    if(file_location.size() >= 4 && file_location.substr(file_location.size() - 4) == ".wav") {
         // Call the play_wav function
         play_wav(file_location.c_str());
         response->success = true;
@@ -57,7 +57,7 @@ void SpeakersNode::play_audio_service_callback(const std::shared_ptr<rae_msgs::s
     }
 
     // Check if the file ends with ".mp3"
-    if (file_location.size() >= 4 && file_location.substr(file_location.size() - 4) == ".mp3") {
+    if(file_location.size() >= 4 && file_location.substr(file_location.size() - 4) == ".mp3") {
         // Call the play_mp3 function
         play_mp3(file_location.c_str());
         response->success = true;
@@ -68,7 +68,6 @@ void SpeakersNode::play_audio_service_callback(const std::shared_ptr<rae_msgs::s
     RCLCPP_ERROR(this->get_logger(), "Unsupported file format: %s", file_location.c_str());
     response->success = false;
 }
-
 
 void SpeakersNode::play_mp3(const char* mp3_file) {
     // Initialize libmpg123
@@ -89,8 +88,6 @@ void SpeakersNode::play_mp3(const char* mp3_file) {
 
     // Set ALSA parameters
 
-    
-
     snd_pcm_set_params(alsaHandle, SND_PCM_FORMAT_S16_LE, SND_PCM_ACCESS_RW_INTERLEAVED, channels, rate, 2, 50000);
 
     size_t buffer_size = mpg123_outblock(mh) * 4;
@@ -98,11 +95,10 @@ void SpeakersNode::play_mp3(const char* mp3_file) {
     size_t err;
 
     while(mpg123_read(mh, buffer, buffer_size, &err) == MPG123_OK) {
-        if(snd_pcm_writei(alsaHandle, buffer, buffer_size/(2*channels)) < 0) {
+        if(snd_pcm_writei(alsaHandle, buffer, buffer_size / (2 * channels)) < 0) {
             std::cerr << "Error in snd_pcm_writei: " << snd_strerror(err) << std::endl;
         }
     }
-
 
     // Cleanup
     delete[] buffer;
@@ -118,38 +114,37 @@ void SpeakersNode::play_wav(const char* wav_file) {
     // Open WAV file
     SF_INFO sfinfo;
     SNDFILE* file = sf_open(wav_file, SFM_READ, &sfinfo);
-    if (!file) {
+    if(!file) {
         RCLCPP_ERROR(this->get_logger(), "Failed to open WAV file: %s", wav_file);
         return;
     }
 
     // Open ALSA device
-    if (snd_pcm_open(&alsaHandle, "default", SND_PCM_STREAM_PLAYBACK, 0) < 0) {
+    if(snd_pcm_open(&alsaHandle, "default", SND_PCM_STREAM_PLAYBACK, 0) < 0) {
         RCLCPP_ERROR(this->get_logger(), "Failed to open ALSA playback device.");
         return;
     }
 
-   // Set ALSA parameters
-    snd_pcm_set_params(alsaHandle, SND_PCM_FORMAT_S32_LE, SND_PCM_ACCESS_RW_INTERLEAVED,
-                       sfinfo.channels, sfinfo.samplerate, 2, 50000);
+    // Set ALSA parameters
+    snd_pcm_set_params(alsaHandle, SND_PCM_FORMAT_S32_LE, SND_PCM_ACCESS_RW_INTERLEAVED, sfinfo.channels, sfinfo.samplerate, 2, 50000);
 
     // Read and play WAV file
     const int BUFFER_SIZE = 4096;
-    int32_t* buffer_wav = new int32_t[BUFFER_SIZE * sfinfo.channels]; // Use int32_t for 32-bit format
+    int32_t* buffer_wav = new int32_t[BUFFER_SIZE * sfinfo.channels];  // Use int32_t for 32-bit format
     sf_count_t readCount;
 
-    const float gain = 64.0f; // Adjust this factor for desired gain
+    const float gain = 64.0f;  // Adjust this factor for desired gain
 
-    while ((readCount = sf_readf_int(file, buffer_wav, BUFFER_SIZE)) > 0) {
+    while((readCount = sf_readf_int(file, buffer_wav, BUFFER_SIZE)) > 0) {
         // Apply gain to the samples
-        for (int i = 0; i < readCount * sfinfo.channels; ++i) {
+        for(int i = 0; i < readCount * sfinfo.channels; ++i) {
             float sample = static_cast<float>(buffer_wav[i]) / std::numeric_limits<int32_t>::max();
-            sample *= gain; // Apply gain
+            sample *= gain;  // Apply gain
             buffer_wav[i] = static_cast<int32_t>(sample * std::numeric_limits<int32_t>::max());
         }
 
         // Write the processed buffer to the playback device
-        if (snd_pcm_writei(alsaHandle, buffer_wav, readCount) < 0) {
+        if(snd_pcm_writei(alsaHandle, buffer_wav, readCount) < 0) {
             std::cerr << "Error in snd_pcm_writei: " << snd_strerror(readCount) << std::endl;
             break;
         }
@@ -162,7 +157,6 @@ void SpeakersNode::play_wav(const char* wav_file) {
 
     return;
 }
-
 
 }  // namespace rae_hw
 

--- a/rae_hw/src/rae_motors.cpp
+++ b/rae_hw/src/rae_motors.cpp
@@ -77,15 +77,15 @@ void RaeMotor::controlSpeed() {
 
         // Apply dead zone compensation
         float compensatedSpeed = targetSpeed;
-        if (std::abs(targetSpeed) < deadZoneThreshold) {
-            compensatedSpeed = 0.0; // Set to zero or any other desired value outside dead zone
+        if(std::abs(targetSpeed) < deadZoneThreshold) {
+            compensatedSpeed = 0.0;  // Set to zero or any other desired value outside dead zone
         }
 
         if(closedLoop_) {
             auto currTime = std::chrono::high_resolution_clock::now();
             float timeDiff = std::chrono::duration<float>(currTime - prevErrorTime).count();
 
-            if (compensatedSpeed == 0.0) {
+            if(compensatedSpeed == 0.0) {
                 errSum = 0;
                 i_param_counter = 0;
                 dutyCycle = speedToPWM(compensatedSpeed);
@@ -94,25 +94,25 @@ void RaeMotor::controlSpeed() {
                 if(dutyCycleFile.is_open()) {
                     dutyCycleFile << dutyCycle;
                     dutyCycleFile.close();
-            }}
-            else {
-            float error = compensatedSpeed - currSpeed;
-            float eP = error * currPID.P;
-            if(i_param_counter == 500) {
-                errSum = 0;
-                i_param_counter = 0;
-            }
-            errSum += (error * timeDiff);
-            float eI = errSum * currPID.I;
-            float eD = (error - prevError) / timeDiff * currPID.D;
-            float outSpeed = compensatedSpeed + eP + eI + eD;
-            dutyCycle = speedToPWM(outSpeed);
-            dir = (outSpeed >= 0) ^ reversePhPinLogic_; 
-            prevError = error;
-            i_param_counter++;
+                }
+            } else {
+                float error = compensatedSpeed - currSpeed;
+                float eP = error * currPID.P;
+                if(i_param_counter == 500) {
+                    errSum = 0;
+                    i_param_counter = 0;
+                }
+                errSum += (error * timeDiff);
+                float eI = errSum * currPID.I;
+                float eD = (error - prevError) / timeDiff * currPID.D;
+                float outSpeed = compensatedSpeed + eP + eI + eD;
+                dutyCycle = speedToPWM(outSpeed);
+                dir = (outSpeed >= 0) ^ reversePhPinLogic_;
+                prevError = error;
+                i_param_counter++;
             }
             prevErrorTime = currTime;
-            
+
         } else {
             dutyCycle = speedToPWM(compensatedSpeed);
             dir = (compensatedSpeed >= 0) ^ reversePhPinLogic_;

--- a/rae_hw/src/rae_motors.cpp
+++ b/rae_hw/src/rae_motors.cpp
@@ -84,6 +84,18 @@ void RaeMotor::controlSpeed() {
         if(closedLoop_) {
             auto currTime = std::chrono::high_resolution_clock::now();
             float timeDiff = std::chrono::duration<float>(currTime - prevErrorTime).count();
+
+            if (compensatedSpeed == 0.0) {
+                errSum = 0;
+                i_param_counter = 0;
+                dutyCycle = speedToPWM(compensatedSpeed);
+                dir = (compensatedSpeed >= 0) ^ reversePhPinLogic_;
+                prevError = 0;
+                if(dutyCycleFile.is_open()) {
+                    dutyCycleFile << dutyCycle;
+                    dutyCycleFile.close();
+            }}
+            else {
             float error = compensatedSpeed - currSpeed;
             float eP = error * currPID.P;
             if(i_param_counter == 500) {
@@ -95,10 +107,12 @@ void RaeMotor::controlSpeed() {
             float eD = (error - prevError) / timeDiff * currPID.D;
             float outSpeed = compensatedSpeed + eP + eI + eD;
             dutyCycle = speedToPWM(outSpeed);
-            dir = (outSpeed >= 0) ^ reversePhPinLogic_;
-            prevErrorTime = currTime;
+            dir = (outSpeed >= 0) ^ reversePhPinLogic_; 
             prevError = error;
             i_param_counter++;
+            }
+            prevErrorTime = currTime;
+            
         } else {
             dutyCycle = speedToPWM(compensatedSpeed);
             dir = (compensatedSpeed >= 0) ^ reversePhPinLogic_;

--- a/rae_hw/src/rae_motors.cpp
+++ b/rae_hw/src/rae_motors.cpp
@@ -74,10 +74,17 @@ void RaeMotor::controlSpeed() {
         uint32_t dutyCycle;
         float currSpeed = calcSpeed();
         int i_param_counter = 0;
+
+        // Apply dead zone compensation
+        float compensatedSpeed = targetSpeed;
+        if (std::abs(targetSpeed) < deadZoneThreshold) {
+            compensatedSpeed = 0.0; // Set to zero or any other desired value outside dead zone
+        }
+
         if(closedLoop_) {
             auto currTime = std::chrono::high_resolution_clock::now();
             float timeDiff = std::chrono::duration<float>(currTime - prevErrorTime).count();
-            float error = targetSpeed - currSpeed;
+            float error = compensatedSpeed - currSpeed;
             float eP = error * currPID.P;
             if(i_param_counter == 500) {
                 errSum = 0;
@@ -86,15 +93,15 @@ void RaeMotor::controlSpeed() {
             errSum += (error * timeDiff);
             float eI = errSum * currPID.I;
             float eD = (error - prevError) / timeDiff * currPID.D;
-            float outSpeed = targetSpeed + eP + eI + eD;
+            float outSpeed = compensatedSpeed + eP + eI + eD;
             dutyCycle = speedToPWM(outSpeed);
             dir = (outSpeed >= 0) ^ reversePhPinLogic_;
             prevErrorTime = currTime;
             prevError = error;
             i_param_counter++;
         } else {
-            uint32_t dutyCycle = speedToPWM(targetSpeed);
-            dir = (targetSpeed >= 0) ^ reversePhPinLogic_;
+            dutyCycle = speedToPWM(compensatedSpeed);
+            dir = (compensatedSpeed >= 0) ^ reversePhPinLogic_;
             if(dutyCycleFile.is_open()) {
                 dutyCycleFile << dutyCycle;
                 dutyCycleFile.close();

--- a/rae_msgs/CMakeLists.txt
+++ b/rae_msgs/CMakeLists.txt
@@ -16,6 +16,7 @@ rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/ColorPeriod.msg"
   "srv/PlayAudio.srv"
   "srv/RecordAudio.srv"
+  "srv/StopRecording.srv"
   "action/Recording.action"
   DEPENDENCIES std_msgs
 )

--- a/rae_msgs/srv/PlayAudio.srv
+++ b/rae_msgs/srv/PlayAudio.srv
@@ -1,3 +1,3 @@
-string mp3_file
+string file_location
 ---
 bool success

--- a/rae_msgs/srv/StopRecording.srv
+++ b/rae_msgs/srv/StopRecording.srv
@@ -1,0 +1,3 @@
+---
+bool success
+string message

--- a/rae_sdk/rae_sdk/robot/audio.py
+++ b/rae_sdk/rae_sdk/robot/audio.py
@@ -35,7 +35,7 @@ class AudioController:
 
     def play_audio_file(self, audio_file_path):
         req = PlayAudio.Request()
-        req.mp3_file = audio_file_path
+        req.file_location = audio_file_path
         res = self._ros_interface.call_async_srv('/play_audio', req)
         return res
 


### PR DESCRIPTION
- Adds ability to stop recording via service call (timeout of 30 seconds otherwise).

- Adds ability for speaker node to play wav files.

- Changes "mp3_file" request variable from PlayAudio service call as it no longer makes sense (as it can both play wav and mp3), updates lifecycle manager and rae_sdk to account for that.

- Adding gain to wav file playing to account for bit quieter recording.

- Update for pcm params for mp3 playing to use relevant channels better.

- Added a dead zone for motors to not confuse PID controller on low speeds. Should solve RAE moving when command to stop is given.