### PR TITLE
Fix PWM reset bug

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,9 @@ ARG BUILD_TYPE="RelWithDebInfo"
 ARG SIM=0
 ENV DEBIAN_FRONTEND=noninteractive
 
-RUN apt-get update && apt-get -y install --no-install-recommends \
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    apt-get -y install --no-install-recommends \
     software-properties-common \
     libusb-1.0-0-dev \
     python3-colcon-common-extensions \

--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,8 @@ RUN apt-get update && apt-get -y install --no-install-recommends \
     git \
     htop \
     libsndfile1-dev \
-    libsndfile1
+    libsndfile1 \
+    busybox
 
 RUN pip3 install openai ffmpeg-python
 


### PR DESCRIPTION
### Fixing a bug where PWM isn't reset, leading to jerky RAE movement when camera driver launched.

> ## Launch log excerpt
> [INFO] [launch.user]: Resetting PWM.
> [INFO] [busybox devmem 0x20320180 32 0x00000000-14]: process started with pid [274]
> [busybox devmem 0x20320180 32 0x00000000-14] /bin/sh: 1: busybox: not found
> [ERROR] [busybox devmem 0x20320180 32 0x00000000-14]: process has died [pid 274, exit code 127, cmd 'busybox devmem 0x20320180 32 0x00000000'].

Code which execute `busybox` command:
<https://github.com/luxonis/rae-ros/blob/79e017e74049a414678e10f71a319ccac1bde678/rae_camera/launch/rae_camera.launch.py#L19-L21>

The solution is to install `busybox` into docker image.